### PR TITLE
Implement GDPR data privacy endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 <p align="center">
 <a href="./README_en.md">English</a>
 · <a href="./docs/FAQ.md">常见问题</a>
+· <a href="./docs/data-privacy.md">数据隐私</a>
 · <a href="https://github.com/xinnan-tech/xiaozhi-esp32-server/issues">反馈问题</a>
 · <a href="./README.md#%E9%83%A8%E7%BD%B2%E6%96%87%E6%A1%A3">部署文档</a>
 · <a href="https://github.com/xinnan-tech/xiaozhi-esp32-server/releases">更新日志</a>

--- a/README_en.md
+++ b/README_en.md
@@ -12,6 +12,7 @@ Supports MCP endpoints and voiceprint recognition
 <p align="center">
 <a href="./README.md">中文</a>
 · <a href="./docs/FAQ.md">FAQ</a>
+· <a href="./docs/data-privacy.md">Data Privacy</a>
 · <a href="https://github.com/xinnan-tech/xiaozhi-esp32-server/issues">Report Issues</a>
 · <a href="./README.md#%E9%83%A8%E7%BD%B2%E6%96%87%E6%A1%A3">Deployment Docs</a>
 · <a href="https://github.com/xinnan-tech/xiaozhi-esp32-server/releases">Release Notes</a>

--- a/docs/data-privacy.md
+++ b/docs/data-privacy.md
@@ -1,0 +1,30 @@
+# Data Privacy and GDPR Support
+
+This project now includes optional GDPR features. When enabled, users can
+request their stored data or request deletion through new HTTP endpoints.
+
+## Endpoints
+
+- `GET /privacy/data` – Retrieve current conversation logs and memory files.
+- `PUT /privacy/data` – Replace stored memory with the provided request body.
+- `DELETE /privacy/data` – Remove conversation logs and memory files.
+
+These endpoints return `403` if GDPR features are disabled in `config.yaml`.
+
+## Retention Policy
+
+The `gdpr.retention_days` setting defines how long data is stored. When the
+server starts, any log or memory files older than this limit are purged
+automatically.
+
+## Enabling
+
+Edit `data/.config.yaml` or `config.yaml` and set:
+
+```yaml
+gdpr:
+  enabled: true
+  retention_days: 30
+```
+
+This enables GDPR endpoints and sets the retention period to 30 days.

--- a/main/xiaozhi-server/config.yaml
+++ b/main/xiaozhi-server/config.yaml
@@ -55,6 +55,12 @@ log:
   # 设置数据文件路径
   data_dir: data
 
+gdpr:
+  # 是否启用GDPR相关功能
+  enabled: false
+  # 数据保留天数，超过天数的记录会被自动清除
+  retention_days: 30
+
 # 使用完声音文件后删除文件(Delete the sound file when you are done using it)
 delete_audio: true
 # 没有语音输入多久后断开连接(秒)，默认2分钟，即120秒

--- a/main/xiaozhi-server/core/api/privacy_handler.py
+++ b/main/xiaozhi-server/core/api/privacy_handler.py
@@ -1,0 +1,72 @@
+from aiohttp import web
+import os
+import json
+from .base_handler import BaseHandler
+from core.utils.data_privacy import (
+    get_memory_file_path,
+    get_log_file_path,
+)
+
+TAG = __name__
+
+
+class DataPrivacyHandler(BaseHandler):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self.gdpr_config = config.get("gdpr", {})
+
+    def _features_enabled(self) -> bool:
+        return self.gdpr_config.get("enabled", False)
+
+    async def handle_get(self, request):
+        if not self._features_enabled():
+            return web.Response(status=403, text="GDPR features disabled")
+
+        data = {}
+        memory_path = get_memory_file_path(self.config)
+        if os.path.exists(memory_path):
+            with open(memory_path, "r", encoding="utf-8") as f:
+                data["memory"] = f.read()
+
+        log_path = get_log_file_path(self.config)
+        if os.path.exists(log_path):
+            with open(log_path, "r", encoding="utf-8") as f:
+                data["logs"] = f.read()
+
+        response = web.Response(
+            text=json.dumps(data, ensure_ascii=False),
+            content_type="application/json",
+        )
+        self._add_cors_headers(response)
+        return response
+
+    async def handle_delete(self, request):
+        if not self._features_enabled():
+            return web.Response(status=403, text="GDPR features disabled")
+
+        memory_path = get_memory_file_path(self.config)
+        log_path = get_log_file_path(self.config)
+        if os.path.exists(memory_path):
+            os.remove(memory_path)
+        if os.path.exists(log_path):
+            os.remove(log_path)
+
+        response = web.Response(text="deleted")
+        self._add_cors_headers(response)
+        return response
+
+    async def handle_put(self, request):
+        if not self._features_enabled():
+            return web.Response(status=403, text="GDPR features disabled")
+
+        try:
+            body = await request.text()
+            memory_path = get_memory_file_path(self.config)
+            with open(memory_path, "w", encoding="utf-8") as f:
+                f.write(body)
+            response = web.Response(text="updated")
+        except Exception as e:
+            response = web.Response(status=400, text=str(e))
+
+        self._add_cors_headers(response)
+        return response

--- a/main/xiaozhi-server/core/http_server.py
+++ b/main/xiaozhi-server/core/http_server.py
@@ -3,6 +3,8 @@ from aiohttp import web
 from config.logger import setup_logging
 from core.api.ota_handler import OTAHandler
 from core.api.vision_handler import VisionHandler
+from core.api.privacy_handler import DataPrivacyHandler
+from core.utils.data_privacy import purge_expired_data
 
 TAG = __name__
 
@@ -13,6 +15,7 @@ class SimpleHttpServer:
         self.logger = setup_logging()
         self.ota_handler = OTAHandler(config)
         self.vision_handler = VisionHandler(config)
+        self.privacy_handler = DataPrivacyHandler(config)
 
     def _get_websocket_url(self, local_ip: str, port: int) -> str:
         """获取websocket地址
@@ -40,6 +43,9 @@ class SimpleHttpServer:
         if port:
             app = web.Application()
 
+            # 清理过期数据
+            purge_expired_data(self.config)
+
             read_config_from_api = server_config.get("read_config_from_api", False)
 
             if not read_config_from_api:
@@ -57,6 +63,10 @@ class SimpleHttpServer:
                     web.get("/mcp/vision/explain", self.vision_handler.handle_get),
                     web.post("/mcp/vision/explain", self.vision_handler.handle_post),
                     web.options("/mcp/vision/explain", self.vision_handler.handle_post),
+                    web.get("/privacy/data", self.privacy_handler.handle_get),
+                    web.delete("/privacy/data", self.privacy_handler.handle_delete),
+                    web.put("/privacy/data", self.privacy_handler.handle_put),
+                    web.options("/privacy/data", self.privacy_handler.handle_get),
                 ]
             )
 

--- a/main/xiaozhi-server/core/utils/data_privacy.py
+++ b/main/xiaozhi-server/core/utils/data_privacy.py
@@ -1,0 +1,28 @@
+import os
+import time
+from config.config_loader import get_project_dir
+
+
+def get_memory_file_path(config: dict) -> str:
+    return get_project_dir() + "data/.memory.yaml"
+
+
+def get_log_file_path(config: dict) -> str:
+    log_dir = config.get("log", {}).get("log_dir", "tmp")
+    log_file = config.get("log", {}).get("log_file", "server.log")
+    return os.path.join(get_project_dir(), log_dir, log_file)
+
+
+def purge_expired_data(config: dict):
+    gdpr_cfg = config.get("gdpr", {})
+    days = int(gdpr_cfg.get("retention_days", 0))
+    if days <= 0:
+        return
+    expire_seconds = days * 86400
+    now = time.time()
+    for path in [get_memory_file_path(config), get_log_file_path(config)]:
+        if os.path.exists(path) and now - os.path.getmtime(path) > expire_seconds:
+            try:
+                os.remove(path)
+            except OSError:
+                pass


### PR DESCRIPTION
## Summary
- add optional GDPR configuration with data retention
- purge expired memory/log files on startup
- add `/privacy/data` REST endpoints for access, rectification and erasure
- document new features in `docs/data-privacy.md`
- link to new docs from READMEs

## Testing
- `python3 -m py_compile main/xiaozhi-server/core/api/privacy_handler.py main/xiaozhi-server/core/utils/data_privacy.py main/xiaozhi-server/core/http_server.py`

------
https://chatgpt.com/codex/tasks/task_b_688b05066000832e9cd26d635a151596